### PR TITLE
SmartState

### DIFF
--- a/ode_nn/__init__.py
+++ b/ode_nn/__init__.py
@@ -2,3 +2,4 @@ from ode_nn.data.dataset import C19Dataset
 from ode_nn.lit_pandemic import LitPandemic
 from ode_nn.loss_fns import C19MSELoss
 from ode_nn.seiturd import History, SeiturdModel
+from ode_nn.state import SmartState

--- a/ode_nn/state.py
+++ b/ode_nn/state.py
@@ -1,0 +1,75 @@
+"""
+The ``State`` object tracks populations of individuals in a compartment model.
+"""
+from typing import Dict, Iterable, Union
+
+import torch
+
+
+class SmartState:
+    """
+    The popuations of individuals in a compartment model. Under the hood,
+    this class tracks a ``torch.Tensor`` of shape
+    ``(n_days, n_populations, n_regions)``. This class enables an API
+    in which we can use ints and slices to obtain the tensor components
+    directly, and strings to obtain the tensor for a single population.:
+
+    .. code-block:: python
+
+      a_state: State = ...
+      S = a_state["S"]  # shape is (n_days, n_regions)
+      state_slice = a_state[3:7, :, 10:20]  # shape (6, n_populations, 10)
+
+    Args:
+      populations (str, optional): default is 'SEIR'.
+        A string of unique characters for the populations.
+      n_days (int, optional): default is 100
+      n_regions (int, optional): default is 50
+    """
+
+    def __init__(
+        self,
+        populations: str = "SEIR",
+        n_days: int = 100,
+        n_regions: int = 50,
+    ) -> None:
+        assert n_days > 0
+        assert n_regions > 0
+
+        # Unpack and check the populations
+        msg = f"populations must be unique {populations}"
+        assert len(set(populations)) == len(populations), msg
+        self.populations = populations
+        self._pop_set = set(populations)
+
+        # Record the mapping of the population to its position
+        self.mapping: Dict[Union[int, str], Union[int, str]] = dict()
+        for k, pop in enumerate(populations):
+            self.mapping[k] = pop
+            self.mapping[pop] = k
+
+        # Save attriubutes
+        self.n_populations = len(populations)
+        self.n_days = n_days
+        self.n_regions = n_regions
+
+        # Tensor for the state
+        self.tensor = torch.zeros((n_days, self.n_populations, n_regions))
+
+    def __getitem__(self, key: Union[str, int, Iterable]) -> torch.Tensor:
+        # Handle pop name
+        if isinstance(key, str):
+            assert key in self._pop_set, f"invalid population {key}"
+            return self.tensor[:, self.mapping[key]]
+        else:  # Let torch figure it out
+            return self.tensor[key]
+
+    @property
+    def N(self) -> torch.Tensor:
+        """
+        The state summed over the population dimension (dim 2).
+
+        Returns:
+          the total populations summed over all states
+        """
+        return self.tensor.sum(axis=1)

--- a/ode_nn/state.py
+++ b/ode_nn/state.py
@@ -1,7 +1,7 @@
 """
 The ``State`` object tracks populations of individuals in a compartment model.
 """
-from typing import Dict, Iterable, Union
+from typing import Dict, Iterable, Optional, Union
 
 import torch
 
@@ -25,6 +25,10 @@ class SmartState:
         A string of unique characters for the populations.
       n_days (int, optional): default is 100
       n_regions (int, optional): default is 50
+      requires_grad (bool, optional): default ``False``. flag to allow for
+        gradients
+      device (Optional[torch.device], optional): default ``None``. Send the
+        :attr:`tensor` to the device
     """
 
     def __init__(
@@ -32,6 +36,8 @@ class SmartState:
         populations: str = "SEIR",
         n_days: int = 100,
         n_regions: int = 50,
+        requires_grad: bool = False,
+        device: Optional[torch.device] = None,
     ) -> None:
         assert n_days > 0
         assert n_regions > 0
@@ -54,9 +60,28 @@ class SmartState:
         self.n_regions = n_regions
 
         # Tensor for the state
-        self.tensor = torch.zeros((n_days, self.n_populations, n_regions))
+        if device is None:
+            device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+        self.tensor = torch.zeros(
+            (n_days, self.n_populations, n_regions),
+            device=device,
+            requires_grad=requires_grad,
+        )
 
     def __getitem__(self, key: Union[str, int, Iterable]) -> torch.Tensor:
+        """
+        Index the underlying tensor intelligently. If a string was passed in,
+        then return the ``(n_days, n_regions)`` tensor associated with that
+        population. If any other kind of index was passed int, index the
+        :attr:`tensor` attribute directly.
+
+        Args:
+          key (Union[str, int, Iterable]): either a population name or
+            numerical values to index the tensor
+
+        Returns:
+          the population(s) corresponding to the key
+        """
         # Handle pop name
         if isinstance(key, str):
             assert key in self._pop_set, f"invalid population {key}"
@@ -73,3 +98,10 @@ class SmartState:
           the total populations summed over all states
         """
         return self.tensor.sum(axis=1)
+
+    def __len__(self) -> int:
+        return len(self.tensor)
+
+    @property
+    def shape(self) -> torch.Size:
+        return self.tensor.shape

--- a/tests/state_test.py
+++ b/tests/state_test.py
@@ -1,0 +1,45 @@
+"""
+Tests of the ``SmartState``.
+"""
+
+from unittest import TestCase
+
+from ode_nn.state import SmartState
+
+
+class SmartStateTest(TestCase):
+    def test_smoke(self):
+        ss = SmartState()
+        assert ss is not None
+
+    def test_attributes(self):
+        ss = SmartState("SIR", n_days=10, n_regions=42)
+        assert ss.tensor.shape == (10, 3, 42)
+        for k, pop in enumerate("SIR"):
+            assert ss.mapping[pop] == k
+            assert ss.mapping[k] == pop
+
+    def test___getitem__(self):
+        ss = SmartState("SEITURD", n_days=10, n_regions=42)
+        assert ss.tensor.shape == (10, 7, 42)
+        # Check population indexing
+        for pop in list("SEITURD"):
+            x = ss[pop]
+            assert x.shape == (10, 42)
+        # Check numeric indexing
+        s = ss[:5]
+        assert s.shape == (5, 7, 42)
+        s = ss[:5, :3, 10:20]
+        assert s.shape == (5, 3, 10)
+
+    def test_N(self):
+        ss = SmartState("SEITURD", n_days=10, n_regions=42)
+        assert ss.N.shape == (10, 42)
+
+    def test_requires_grad(self):
+        ss = SmartState("SEITURD", n_days=10, n_regions=42, requires_grad=True)
+        assert ss.tensor.requires_grad
+
+    def test_device(self):
+        ss = SmartState("SEITURD", n_days=10, n_regions=42, requires_grad=True)
+        assert not ss.tensor.is_cuda


### PR DESCRIPTION
Closes #8 

This PR creates the `SmartState` class. this will deprecate the `History` and `State` classes and let us use the same class for any compartment model we want (e.g. SIR, SEIR, SEITURD, etc.).

Once this is accepted I will refactor `Seiturd` to use this class.